### PR TITLE
fix vim modeline in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ autocmd BufNewFile,BufReadPost *.y setlocal filetype=goyacc
 Or write mode line at the bottom of your file as below.
 
 ```
-/* vim: ft=goyacc */
+/* vim: set ft=goyacc: */
 ```
 
 


### PR DESCRIPTION
`/* vim: set ft=goyacc */` without a suffix colon will cause an error.
Refer to `:help modeline`, the second form.